### PR TITLE
Fix #880

### DIFF
--- a/tools/chibi-ffi
+++ b/tools/chibi-ffi
@@ -1881,7 +1881,6 @@
                           (else 1))
                     ", \"" (func-stub-name func) "\", "))
              "")
-         "(sexp_proc1)"
          (func-stub-name func)
          (cond
           (default (lambda () (cat ", " (write-default default))))


### PR DESCRIPTION
Fix issue of can't load symbol when load from image, which cause by add extra "(sexp_proc1)" before function name. Error message: "dynamic function lookup failure: <static> (sexp_proc1)sexp_get_sha_stub"